### PR TITLE
Setup release workflow for npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,11 @@ jobs:
       with:
         go-version-file: go.mod
         cache: true
+    - uses: actions/setup-node@v3
+      with:
+        node-version-file: ./es/package.json
+        cache: 'npm'
+        cache-dependency-path: './es/package-lock.json'
     - uses: bufbuild/buf-setup-action@c9fa470ff8561150a2f7ce2cf52a11026c44db72 # v1.25.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,3 +39,8 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish to npm
+      run: ./scripts/release.sh
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      working-directory: ./es

--- a/es/README.md
+++ b/es/README.md
@@ -1,3 +1,11 @@
 # cybozu/protobuf/es
 
 A monorepo for ECMAScript packages.
+
+## release
+
+The release process is common across the entire repository. Please refer to [README.md](../README.md#for-developers).
+
+## versioning
+
+The version of all packages included in this monorepo is aligned with the version of this GitHub repository.

--- a/es/scripts/release.sh
+++ b/es/scripts/release.sh
@@ -2,7 +2,11 @@
 
 set -e
 
-VERSION=$(git describe --tags --abbrev=0 | cut -c 2-)
+# GITHUB_REF is in the form of refs/tags/v1.0.0
+# take the last part of the string and remove the v
+REF=$GITHUB_REF
+TAG=${REF##*/}
+VERSION=${TAG#v}
 
 npm version $VERSION --no-git-tag-version --workspaces
 npm publish --workspaces

--- a/es/scripts/release.sh
+++ b/es/scripts/release.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+VERSION=$(git describe --tags --abbrev=0 | cut -c 2-)
+
+npm version $VERSION --no-git-tag-version --workspaces
+npm publish --workspaces


### PR DESCRIPTION
Just like the Go version, set up our workflow to publish es packages with GitHub Actions triggered by `make create-tag`.

**todo:**

- Set secrets for npm registry