### PR TITLE
Set `registry-url` for `setup-node` in `release.yaml`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ jobs:
         node-version-file: ./es/package.json
         cache: 'npm'
         cache-dependency-path: './es/package-lock.json'
+        registry-url: 'https://registry.npmjs.org'
     - uses: bufbuild/buf-setup-action@eb60cd0de4f14f1f57cf346916b8cd69a9e7ed0b # v1.26.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ref: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry