### PR TITLE
Migrate to buf v2 config format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for compiling protobuf files
 
 # Tool versions
-BUF_VERSION = 1.30.0
+BUF_VERSION = 1.32.0
 GO_VERSION := $(shell awk '/^go / {print $$2}' go.mod)
 PROTOC_GEN_GO_VERSION := $(shell awk '/google.golang.org\/protobuf/ {print substr($$NF, 2)}' go.mod)
 

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,11 +1,17 @@
-version: v1
+version: v2
 name: buf.build/cybozu/protobuf
-breaking:
-  use:
-    - FILE
 lint:
   use:
     - BASIC
   except:
-    - ENUM_PASCAL_CASE
     - ENUM_NO_ALLOW_ALIAS
+    - ENUM_PASCAL_CASE
+    - FIELD_NOT_REQUIRED
+    - PACKAGE_NO_IMPORT_CYCLE
+  disallow_comment_ignores: true
+breaking:
+  use:
+    - FILE
+  except:
+    - EXTENSION_NO_DELETE
+    - FIELD_SAME_DEFAULT


### PR DESCRIPTION
I used `buf config migrate` for the migration.
